### PR TITLE
Update user_info.go

### DIFF
--- a/pkg/idp/oauth/user_info.go
+++ b/pkg/idp/oauth/user_info.go
@@ -113,7 +113,7 @@ func extractUserInfoRoles(m map[string]interface{}) []string {
 	entries := make(map[string]interface{})
 	var roles []string
 	for k, v := range m {
-		if !strings.HasSuffix(k, "roles") && !strings.HasSuffix(k, "groups") {
+		if !strings.HasSuffix(k, "roles") && !strings.HasSuffix(k, "groups") && !strings.HasSuffix(k, "role") && !strings.HasSuffix(k, "group") {
 			continue
 		}
 		switch values := v.(type) {


### PR DESCRIPTION
Also match singular key forms role and group when extracting roles from user info.

In other parts of the code base, these four variants of the key name are also used all together.

Our IdP currently uses "role" in singular form so this would be a huge benefit for us ;)

I've tested the change with a local xcaddy build and am happy with the results and could not find any problems so far.